### PR TITLE
Update parsl_utils generated Parsl configuration to work with new versions of Parsl

### DIFF
--- a/config.py
+++ b/config.py
@@ -173,7 +173,7 @@ for label in resource_labels:
             working_dir =  resource_inputs['resource']['jobdir'],
             cores_per_worker = cores_per_worker,
             worker_logdir_root = worker_logdir_root,
-            address = resource_inputs['resource']['publicIp'].split('@')[1],
+            address = resource_inputs['resource']['privateIp'],
             provider = provider,
             storage_access = storage_access,
             launch_cmd='process_worker_pool.py {debug} {max_workers} -a '+hostname+' -p {prefetch_capacity} -c {cores_per_worker} -m {mem_per_worker} --poll {poll_period} --task_port={task_port} --result_port={result_port} --logdir={logdir} --block_id={{block_id}} --hb_period={heartbeat_period} {address_probe_timeout_string} --hb_threshold={heartbeat_threshold} --cpu-affinity {cpu_affinity} --available-accelerators {accelerators} --start-method {start_method}'

--- a/config.py
+++ b/config.py
@@ -173,7 +173,7 @@ for label in resource_labels:
             working_dir =  resource_inputs['resource']['jobdir'],
             cores_per_worker = cores_per_worker,
             worker_logdir_root = worker_logdir_root,
-            address = resource_inputs['resource']['publicIp'].split('@')[1],
+            address = resource_inputs['resource']['privateIp'],
             provider = provider,
             storage_access = storage_access,
             launch_cmd='process_worker_pool.py {debug} {max_workers} -a '+resource_inputs['resource']['privateIp']+' -p {prefetch_capacity} -c {cores_per_worker} -m {mem_per_worker} --poll {poll_period} --task_port={task_port} --result_port={result_port} --logdir={logdir} --block_id={{block_id}} --hb_period={heartbeat_period} {address_probe_timeout_string} --hb_threshold={heartbeat_threshold} --cpu-affinity {cpu_affinity} --available-accelerators {accelerators} --start-method {start_method}'

--- a/config.py
+++ b/config.py
@@ -177,7 +177,7 @@ for label in resource_labels:
             address = '*', #resource_inputs['resource']['privateIp'],
             provider = provider,
             storage_access = storage_access,
-            launch_cmd='process_worker_pool.py {debug} {max_workers} -a '+resource_inputs['resource']['privateIp']+' -p {prefetch_capacity} -c {cores_per_worker} -m {mem_per_worker} --poll {poll_period} --task_port={task_port} --result_port={result_port} --logdir={logdir} --block_id={{block_id}} --hb_period={heartbeat_period} {address_probe_timeout_string} --hb_threshold={heartbeat_threshold} --cpu-affinity {cpu_affinity} --available-accelerators {accelerators} --start-method {start_method}'
+            launch_cmd='process_worker_pool.py {debug} {max_workers} -a '+resource_inputs['resource']['privateIp']+' -p {prefetch_capacity} -c {cores_per_worker} -m {mem_per_worker} --poll {poll_period} --task_port={task_port} --result_port={result_port} --logdir={logdir} --block_id={{block_id}} --hb_period={heartbeat_period} {address_probe_timeout_string} --hb_threshold={heartbeat_threshold} --cpu-affinity {cpu_affinity}'
         )
     )
     

--- a/config.py
+++ b/config.py
@@ -175,7 +175,8 @@ for label in resource_labels:
             worker_logdir_root = worker_logdir_root,
             address = resource_inputs['resource']['privateIp'],
             provider = provider,
-            storage_access = storage_access
+            storage_access = storage_access,
+            launch_cmd='process_worker_pool.py {debug} {max_workers} -a '+hostname+' -p {prefetch_capacity} -c {cores_per_worker} -m {mem_per_worker} --poll {poll_period} --task_port={task_port} --result_port={result_port} --logdir={logdir} --block_id={{block_id}} --hb_period={heartbeat_period} {address_probe_timeout_string} --hb_threshold={heartbeat_threshold} --cpu-affinity {cpu_affinity} --available-accelerators {accelerators} --start-method {start_method}'
         )
     )
     

--- a/config.py
+++ b/config.py
@@ -173,7 +173,7 @@ for label in resource_labels:
             working_dir =  resource_inputs['resource']['jobdir'],
             cores_per_worker = cores_per_worker,
             worker_logdir_root = worker_logdir_root,
-            address = resource_inputs['resource']['privateIp'],
+            address = resource_inputs['resource']['publicIp'].split('@')[1],
             provider = provider,
             storage_access = storage_access,
             launch_cmd='process_worker_pool.py {debug} {max_workers} -a '+hostname+' -p {prefetch_capacity} -c {cores_per_worker} -m {mem_per_worker} --poll {poll_period} --task_port={task_port} --result_port={result_port} --logdir={logdir} --block_id={{block_id}} --hb_period={heartbeat_period} {address_probe_timeout_string} --hb_threshold={heartbeat_threshold} --cpu-affinity {cpu_affinity} --available-accelerators {accelerators} --start-method {start_method}'

--- a/config.py
+++ b/config.py
@@ -173,10 +173,10 @@ for label in resource_labels:
             working_dir =  resource_inputs['resource']['jobdir'],
             cores_per_worker = cores_per_worker,
             worker_logdir_root = worker_logdir_root,
-            address = resource_inputs['resource']['privateIp'],
+            address = resource_inputs['resource']['publicIp'].split('@')[1],
             provider = provider,
             storage_access = storage_access,
-            launch_cmd='process_worker_pool.py {debug} {max_workers} -a '+hostname+' -p {prefetch_capacity} -c {cores_per_worker} -m {mem_per_worker} --poll {poll_period} --task_port={task_port} --result_port={result_port} --logdir={logdir} --block_id={{block_id}} --hb_period={heartbeat_period} {address_probe_timeout_string} --hb_threshold={heartbeat_threshold} --cpu-affinity {cpu_affinity} --available-accelerators {accelerators} --start-method {start_method}'
+            launch_cmd='process_worker_pool.py {debug} {max_workers} -a '+resource_inputs['resource']['privateIp']+' -p {prefetch_capacity} -c {cores_per_worker} -m {mem_per_worker} --poll {poll_period} --task_port={task_port} --result_port={result_port} --logdir={logdir} --block_id={{block_id}} --hb_period={heartbeat_period} {address_probe_timeout_string} --hb_threshold={heartbeat_threshold} --cpu-affinity {cpu_affinity} --available-accelerators {accelerators} --start-method {start_method}'
         )
     )
     

--- a/config.py
+++ b/config.py
@@ -118,7 +118,7 @@ for label in resource_labels:
     # One instance per executor
     storage_access = [ 
         PWRSyncStaging(label, 
-	    head_node_private_ip=resource_inputs['resource']['privateIp']),
+	    resource_inputs['resource']['privateIp']),
         PWGsutil(label),
         PWS3(label)
     ]

--- a/config.py
+++ b/config.py
@@ -173,7 +173,7 @@ for label in resource_labels:
             working_dir =  resource_inputs['resource']['jobdir'],
             cores_per_worker = cores_per_worker,
             worker_logdir_root = worker_logdir_root,
-            address = resource_inputs['resource']['privateIp'],
+            address = '*', #resource_inputs['resource']['privateIp'],
             provider = provider,
             storage_access = storage_access,
             launch_cmd='process_worker_pool.py {debug} {max_workers} -a '+resource_inputs['resource']['privateIp']+' -p {prefetch_capacity} -c {cores_per_worker} -m {mem_per_worker} --poll {poll_period} --task_port={task_port} --result_port={result_port} --logdir={logdir} --block_id={{block_id}} --hb_period={heartbeat_period} {address_probe_timeout_string} --hb_threshold={heartbeat_threshold} --cpu-affinity {cpu_affinity} --available-accelerators {accelerators} --start-method {start_method}'

--- a/config.py
+++ b/config.py
@@ -117,7 +117,8 @@ for label in resource_labels:
     # Data provider:
     # One instance per executor
     storage_access = [ 
-        PWRSyncStaging(label),
+        PWRSyncStaging(label, 
+	    head_node_private_ip=resource_inputs['resource']['privateIp']),
         PWGsutil(label),
         PWS3(label)
     ]

--- a/data_provider/rsync.py
+++ b/data_provider/rsync.py
@@ -38,13 +38,14 @@ def get_stage_out_cmd(file, jumphost = None):
 
     return cmd
 
-class PWRSyncStaging(pwstaging.PWStaging):
+class PWRSyncStaging(pwstaging.PWStaging, head_node_private_ip):
     """
     This is a modification of the official staging provider 
     https://parsl.readthedocs.io/en/latest/stubs/parsl.data_provider.rsync.RSyncStaging.html
-    with two changes:
+    with three changes:
         1. Add -avzq option to rsync
         2. Make parent directory of file.path if it does not exist
+        3. Allow the user the specify the private IP of the head node.
 
     This staging provider will execute rsync on worker nodes
     to stage in files from a remote location.
@@ -53,6 +54,14 @@ class PWRSyncStaging(pwstaging.PWStaging):
     initialization could include an appropriate SSH key configuration.
     The submit side will need to run an rsync-compatible server (for example,
     an ssh server with the rsync binary installed)
+
+    It is assumed that the SSH tunnels/config from the PW platform
+    are already in place so that worker nodes can simply
+         ssh -J <head_node_private_ip> usercontainer
+    in order to reach the PW user's IDE. All rsync commands here are
+    prefixed with ssh -J and this approach works even if the Parsl
+    app is for some reason running on the head node itself instead
+    of the worker nodes.
     """
 
     def __init__(self, executor_label, logging_level = logging.INFO):
@@ -62,19 +71,13 @@ class PWRSyncStaging(pwstaging.PWStaging):
 
     def replace_task(self, dm, executor, file, f):
         working_dir = dm.dfk.executors[executor].working_dir
-        #cmd = get_stage_in_cmd(file, jumphost = dm.dfk.executors[executor].address)
-        # Get private IP address of head node from the launch_cmd
-        # Need to parse the -a {address} option (so the address itself is
-        # first after the split) and then split again to discard the rest of the options.
-        cmd = get_stage_in_cmd(file, jumphost = dm.dfk.executors[executor].launch_cmd.split('-a')[1].split('-')[0])
+        cmd = get_stage_in_cmd(file, jumphost = head_node_private_ip)
         cmd_id = self._get_cmd_id(cmd)  
         return pwstaging.in_task_stage_in_cmd_wrapper(f, file, working_dir, cmd, cmd_id, self.logger.getEffectiveLevel())
     
     def replace_task_stage_out(self, dm, executor, file, f):
         working_dir = dm.dfk.executors[executor].working_dir
-        #cmd = get_stage_out_cmd(file, jumphost = dm.dfk.executors[executor].address)
-        # See comments in replace_task, above.
-        cmd = get_stage_out_cmd(file, jumphost = dm.dfk.executors[executor].launch_cmd.split('-a')[1].split('-')[0])
+        cmd = get_stage_out_cmd(file, jumphost = head_node_private_ip)
         cmd_id = self._get_cmd_id(cmd)  
         cmd_id = self._get_cmd_id(cmd)  
         return pwstaging.in_task_stage_out_cmd_wrapper(f, file, working_dir, cmd, cmd_id, self.logger.getEffectiveLevel())

--- a/data_provider/rsync.py
+++ b/data_provider/rsync.py
@@ -38,7 +38,7 @@ def get_stage_out_cmd(file, jumphost = None):
 
     return cmd
 
-class PWRSyncStaging(pwstaging.PWStaging, head_node_private_ip = None):
+class PWRSyncStaging(pwstaging.PWStaging, head_node_private_ip):
     """
     This is a modification of the official staging provider 
     https://parsl.readthedocs.io/en/latest/stubs/parsl.data_provider.rsync.RSyncStaging.html

--- a/data_provider/rsync.py
+++ b/data_provider/rsync.py
@@ -62,12 +62,19 @@ class PWRSyncStaging(pwstaging.PWStaging):
 
     def replace_task(self, dm, executor, file, f):
         working_dir = dm.dfk.executors[executor].working_dir
-        cmd = get_stage_in_cmd(file, jumphost = dm.dfk.executors[executor].address)
+        #cmd = get_stage_in_cmd(file, jumphost = dm.dfk.executors[executor].address)
+        # Get private IP address of head node from the launch_cmd
+        # Need to parse the -a {address} option (so the address itself is
+        # first after the split) and then split again to discard the rest of the options.
+        cmd = get_stage_in_cmd(file, jumphost = dm.dfk.executors[executor].launch_cmd.split('-a')[1].split('-')[0])
         cmd_id = self._get_cmd_id(cmd)  
         return pwstaging.in_task_stage_in_cmd_wrapper(f, file, working_dir, cmd, cmd_id, self.logger.getEffectiveLevel())
     
     def replace_task_stage_out(self, dm, executor, file, f):
         working_dir = dm.dfk.executors[executor].working_dir
-        cmd = get_stage_out_cmd(file, jumphost = dm.dfk.executors[executor].address)
+        #cmd = get_stage_out_cmd(file, jumphost = dm.dfk.executors[executor].address)
+        # See comments in replace_task, above.
+        cmd = get_stage_out_cmd(file, jumphost = dm.dfk.executors[executor].launch_cmd.split('-a')[1].split('-')[0])
+        cmd_id = self._get_cmd_id(cmd)  
         cmd_id = self._get_cmd_id(cmd)  
         return pwstaging.in_task_stage_out_cmd_wrapper(f, file, working_dir, cmd, cmd_id, self.logger.getEffectiveLevel())

--- a/data_provider/rsync.py
+++ b/data_provider/rsync.py
@@ -38,7 +38,7 @@ def get_stage_out_cmd(file, jumphost = None):
 
     return cmd
 
-class PWRSyncStaging(pwstaging.PWStaging, head_node_private_ip):
+class PWRSyncStaging(pwstaging.PWStaging, head_node_private_ip = None):
     """
     This is a modification of the official staging provider 
     https://parsl.readthedocs.io/en/latest/stubs/parsl.data_provider.rsync.RSyncStaging.html
@@ -62,6 +62,11 @@ class PWRSyncStaging(pwstaging.PWStaging, head_node_private_ip):
     prefixed with ssh -J and this approach works even if the Parsl
     app is for some reason running on the head node itself instead
     of the worker nodes.
+
+    The default value is set to None which will disable the use of
+    ssh -J and assume that the node that is running the rsync command
+    has direct ssh access to the host the workflow configuration is
+    pointing to.
     """
 
     def __init__(self, executor_label, logging_level = logging.INFO):

--- a/data_provider/rsync.py
+++ b/data_provider/rsync.py
@@ -38,7 +38,7 @@ def get_stage_out_cmd(file, jumphost = None):
 
     return cmd
 
-class PWRSyncStaging(pwstaging.PWStaging, head_node_private_ip):
+class PWRSyncStaging(pwstaging.PWStaging):
     """
     This is a modification of the official staging provider 
     https://parsl.readthedocs.io/en/latest/stubs/parsl.data_provider.rsync.RSyncStaging.html
@@ -69,20 +69,21 @@ class PWRSyncStaging(pwstaging.PWStaging, head_node_private_ip):
     pointing to.
     """
 
-    def __init__(self, executor_label, logging_level = logging.INFO):
+    def __init__(self, executor_label, head_node_private_ip = None, logging_level = logging.INFO):
         self.executor_label = executor_label
         self.logging_level = logging_level
         super().__init__('file', executor_label, logging_level = logging_level)
+        self.head_node_private_ip = head_node_private_ip
 
     def replace_task(self, dm, executor, file, f):
         working_dir = dm.dfk.executors[executor].working_dir
-        cmd = get_stage_in_cmd(file, jumphost = head_node_private_ip)
+        cmd = get_stage_in_cmd(file, jumphost = self.head_node_private_ip)
         cmd_id = self._get_cmd_id(cmd)  
         return pwstaging.in_task_stage_in_cmd_wrapper(f, file, working_dir, cmd, cmd_id, self.logger.getEffectiveLevel())
     
     def replace_task_stage_out(self, dm, executor, file, f):
         working_dir = dm.dfk.executors[executor].working_dir
-        cmd = get_stage_out_cmd(file, jumphost = head_node_private_ip)
+        cmd = get_stage_out_cmd(file, jumphost = self.head_node_private_ip)
         cmd_id = self._get_cmd_id(cmd)  
         cmd_id = self._get_cmd_id(cmd)  
         return pwstaging.in_task_stage_out_cmd_wrapper(f, file, working_dir, cmd, cmd_id, self.logger.getEffectiveLevel())


### PR DESCRIPTION
Parsl PR #2828 (going from version 2023.07.17 to 2023.07.24) changed how the Interchange address is set in the Parsl configuration. The changes to the `config.py` and `PWRsyncStaging` allow for these changes **and** are backwards compatible with Parsl v1.2.0.

This has been tested with the multi-site [MDLite workflow](https://github.com/parallelworks/mdlite-workflow) and [simple_parsl_demo](https://github.com/parallelworks/simple_parsl_demo).

The key overarching concept is that the `HighThroughputExecutor` Interchange runs in the location of where the Parsl config is loaded by the Parsl script (i.e. in the PW usercontainer). For multi-site workflows, there is one Interchange for each HTEX. This means that the address of the HTEX has to be set to `*` to allow for whatever the local address is but the address for the head node of the cluster has to be explicitly inserted into the Parsl configuration for properly connecting the workers and launching `process_worker_pool.py`.