### PR TITLE
Remove RUN_DIR check - not needed and fails to pass bools

### DIFF
--- a/config.py
+++ b/config.py
@@ -36,8 +36,6 @@ def get_provider_parameters_from_form(resource_inputs):
         if k.startswith('_parsl_provider_'):
             key = k.replace('_parsl_provider_', '')
             provider_options[key] = guess_correct_type(v)
-            if '__RUN_DIR__' in v:
-                provider_options[key] = v.replace('__RUN_DIR__', resource_inputs['resource']['jobdir'])
 
     return provider_options
 


### PR DESCRIPTION
RUN_DIR is no longer handled in parsl_utils, so this logic is not needed.  Furthermore, if a user attempts to pass a boolean value to a Parsl provider (i.e. SlurmProvider.exclusive=True), the if statement fails because it cannot iterate on a boolean.

I've tested this on `cloud.parallel.works` and I am able to pass the `exclusive` option to the `SlurmProvider`.